### PR TITLE
Check sosiski2 for missing end keyword

### DIFF
--- a/sosiski2
+++ b/sosiski2
@@ -3579,7 +3579,6 @@ testESPBtn.MouseButton1Click:Connect(function()
         end
     else
         print("YBA: Предметы YBA не найдены или произошла ошибка")
-    end
 end)
 
 -- Конец файла


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove extraneous `end` keyword to fix Lua syntax error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The Roblox error `Expected 'end' ... got <eof>` indicated an unclosed function. Investigation revealed an extra `end` on line 3582 (old line number) which caused an imbalance in block closures, leading to the syntax error. Removing this extraneous `end` resolves the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0ca0d2e-7c8a-4d43-a124-a5d9a36395a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0ca0d2e-7c8a-4d43-a124-a5d9a36395a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>