### PR TITLE
Исправить ошибки в файле sosiski2

### DIFF
--- a/sosiski2
+++ b/sosiski2
@@ -2047,9 +2047,6 @@ FOVCircle.Visible = Config.Aimbot.Enabled
 FOVCircle.Position = Vector2.new(cam.ViewportSize.X/2, cam.ViewportSize.Y/2)
 FOVCircle.Color = Config.Aimbot.FOVRainbow and getRainbow() or Config.Aimbot.FOVColor
 FOVCircle.Radius = Config.Aimbot.FOV
-
-
-    
 end)
 
 

--- a/sosiski2
+++ b/sosiski2
@@ -1906,8 +1906,8 @@ end
 
 local function onPlayerRespawned(player)
     if Config.ESP.Enabled and player ~= Players.LocalPlayer then
-        spawn(function()
-            wait(2) 
+        task.spawn(function()
+            task.wait(2) 
             if isPlayerAlive(player) then
                 createOrUpdateESP(player)
             end
@@ -1972,21 +1972,22 @@ local function getClosestTarget()
     local closest, minDist = nil, Config.Aimbot.FOV
 
     for _, p in ipairs(Players:GetPlayers()) do
-        if p == Players.LocalPlayer then continue end
-        if Config.Aimbot.TeamCheck and p.Team == Players.LocalPlayer.Team then continue end
-        if not isAlive(p) then continue end
-        if Config.Aimbot.VisibilityCheck and not rayVisible(p) then continue end
+        if p == Players.LocalPlayer then goto continue end
+        if Config.Aimbot.TeamCheck and p.Team == Players.LocalPlayer.Team then goto continue end
+        if not isAlive(p) then goto continue end
+        if Config.Aimbot.VisibilityCheck and not rayVisible(p) then goto continue end
 
         local head = p.Character and p.Character:FindFirstChild("Head")
-        if not head then continue end
+        if not head then goto continue end
         local screenPos, onScreen = cam:WorldToViewportPoint(head.Position)
-        if not onScreen then continue end
+        if not onScreen then goto continue end
 
         local dist = (Vector2.new(screenPos.X, screenPos.Y) - Vector2.new(cam.ViewportSize.X/2, cam.ViewportSize.Y/2)).Magnitude
         if dist < minDist then
             closest = head
             minDist = dist
         end
+        ::continue::
     end
     return closest
 end
@@ -1995,7 +1996,7 @@ end
 RunService.RenderStepped:Connect(function()
     local cam = workspace.CurrentCamera
     for _, player in ipairs(Players:GetPlayers()) do
-        if player == Players.LocalPlayer then continue end
+        if player == Players.LocalPlayer then goto continue2 end
         
         local char = player.Character
         local hum = char and char:FindFirstChild("Humanoid")
@@ -2028,6 +2029,7 @@ RunService.RenderStepped:Connect(function()
             
             removeESP(player)
         end
+        ::continue2::
     end
 
     
@@ -3042,7 +3044,7 @@ speedInput("Custom SpeedHack Speed", SpeedHackConfig.Speed, function(v)
 end)
 
 local divider5 = Instance.new("Frame", innerContainer)
-divider5.Position = UDim2.new(0, 5, 0, yOffset)
+divider5.Position = UDim2.new(0, 5, 0, 0)
 divider5.Size = UDim2.new(1, -10, 0, 2)
 divider5.BackgroundColor3 = Color3.fromRGB(60, 60, 60)
 divider5.BorderSizePixel = 0
@@ -3226,8 +3228,7 @@ local function createPlayerListInMenu()
             for _, btn in ipairs(innerContainer:GetChildren()) do
                 if btn:IsA("TextButton") and 
                    btn ~= startTeleportBtn and 
-                   btn ~= stopTeleportBtn and 
-                   btn ~= updatePlayersBtn and
+                   btn ~= stopTeleportBtn and
                    btn.Size.Y.Offset == 30 then
                     btn.BackgroundColor3 = Color3.fromRGB(50,50,60)
                     btn.BorderColor3 = Color3.fromRGB(100,100,120)
@@ -3312,8 +3313,7 @@ local function updatePlayerList()
             for _, btn in ipairs(innerContainer:GetChildren()) do
                 if btn:IsA("TextButton") and 
                    btn ~= startTeleportBtn and 
-                   btn ~= stopTeleportBtn and 
-                   btn ~= updatePlayersBtn and
+                   btn ~= stopTeleportBtn and
                    btn.Size.Y.Offset == 30 then
                     btn.BackgroundColor3 = Color3.fromRGB(50,50,60)
                     btn.BorderColor3 = Color3.fromRGB(100,100,120)


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix Lua syntax and runtime errors in `sosiski2` to ensure correct script execution.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses several issues, including replacing `spawn` and `wait` with `task.spawn` and `task.wait` respectively, converting `continue` statements to `goto` labels (as `continue` is not a Lua keyword), resolving undefined variable references, and correcting an incomplete statement caused by extraneous newlines.

---
<a href="https://cursor.com/background-agent?bcId=bc-3160d05b-10d0-4ef0-afed-c76cdecff00d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3160d05b-10d0-4ef0-afed-c76cdecff00d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>