### PR TITLE
Fix blur, accent color, and translations

### DIFF
--- a/sosiski3
+++ b/sosiski3
@@ -296,6 +296,11 @@ local Languages = {
         AntiTimeStop = "ANTI TIME STOP",
         StartTeleport = "START TELEPORT",
         StopTeleport = "STOP TELEPORT",
+        SelectedPlayer = "Selected Player",
+        SelectPlayerForTeleport = "Select Player for Teleport",
+        StandRange = "Stand Range",
+        Item = "Item",
+        AntiTimeStopShort = "Anti Time Stop",
     },
     Russian = {
         -- Заголовки
@@ -330,6 +335,11 @@ local Languages = {
         AntiTimeStop = "АНТИ ОСТАНОВКА ВРЕМЕНИ",
         StartTeleport = "НАЧАТЬ ТЕЛЕПОРТ",
         StopTeleport = "ОСТАНОВИТЬ ТЕЛЕПОРТ",
+        SelectedPlayer = "Выбранный игрок",
+        SelectPlayerForTeleport = "Выбрать игрока для телепорта",
+        StandRange = "Дальность стенда",
+        Item = "Предмет",
+        AntiTimeStopShort = "Анти остановка времени",
     }
 }
 
@@ -356,8 +366,39 @@ local function updateAccentColor()
         reopenButton.BackgroundColor3 = MenuSettings.AccentColor
     end
     
-    -- Обновляем цвет всех ползунков (будет применяться при следующем обновлении)
-    -- Цвет будет применен в функции createToggleSlider
+    -- Обновляем цвет подсветки вкладок
+    if leftPanel then
+        for _, btn in pairs(leftPanel:GetChildren()) do
+            if btn:IsA("TextButton") then
+                local highlight = btn:FindFirstChild("Highlight")
+                if highlight then
+                    highlight.BackgroundColor3 = MenuSettings.AccentColor
+                end
+            end
+        end
+    end
+    
+    -- Обновляем цвет всех активных ползунков
+    local function updateSliderColors(parent)
+        for _, child in pairs(parent:GetChildren()) do
+            if child:IsA("Frame") then
+                -- Ищем ползунок в контейнере
+                local sliderBack = child:FindFirstChild("ToggleSlider")
+                if sliderBack then
+                    -- Это ползунок, обновляем его цвет если он активен
+                    local isEnabled = sliderBack.BackgroundColor3 ~= Color3.fromRGB(100, 100, 100)
+                    if isEnabled then
+                        sliderBack.BackgroundColor3 = MenuSettings.AccentColor
+                    end
+                end
+                updateSliderColors(child)
+            end
+        end
+    end
+    
+    if functionsContainer then
+        updateSliderColors(functionsContainer)
+    end
 end
 
 -- Функция обновления всех текстов
@@ -465,7 +506,7 @@ local YBAFreeCamera = {} do
         if move.Magnitude > 0 then
             local cameraCFrame = CFrame.new(standPosition) * CFrame.Angles(0, cameraRot.Y, 0)
             local worldMove = cameraCFrame:VectorToWorldSpace(move)
-            local standSpeed = math.floor(YBAConfig.UndergroundControl.FlightSpeed)
+            local standSpeed = math.floor(YBAConfig.StandControlSpeed * 50)
             
             if isShiftPressed then
                 standSpeed = standSpeed + 50
@@ -3531,7 +3572,7 @@ for i, buttonData in ipairs(navButtons) do
         highlight.Name = "Highlight"
         highlight.Size = UDim2.new(0, 3, 1, 0)
         highlight.Position = UDim2.new(0, 0, 0, 0)
-        highlight.BackgroundColor3 = Color3.fromRGB(0, 255, 0)
+        highlight.BackgroundColor3 = MenuSettings.AccentColor
         highlight.BorderSizePixel = 0
         
         local highlightCorner = Instance.new("UICorner", highlight)
@@ -3558,7 +3599,7 @@ for i, buttonData in ipairs(navButtons) do
         highlight.Name = "Highlight"
         highlight.Size = UDim2.new(0, 3, 1, 0)
         highlight.Position = UDim2.new(0, 0, 0, 0)
-        highlight.BackgroundColor3 = Color3.fromRGB(0, 255, 0)
+        highlight.BackgroundColor3 = MenuSettings.AccentColor
         highlight.BorderSizePixel = 0
         
         local highlightCorner = Instance.new("UICorner", highlight)
@@ -3862,6 +3903,10 @@ local function createToggleSlider(label, default, callback)
             callback(isEnabled)
         end
     end)
+    
+    -- Сохраняем ссылку на ползунок для обновления цвета
+    sliderBack.Name = "ToggleSlider"
+    sliderBack.Parent = container
     
     currentY = currentY + 40 + padding
     return container
@@ -4306,7 +4351,7 @@ function showContent(tabName)
         local selectedPlayerLabel = Instance.new("TextLabel", functionsContainer)
         selectedPlayerLabel.Size = UDim2.new(1, -10, 0, 24)
         selectedPlayerLabel.Position = UDim2.new(0, 5, 0, currentY)
-        selectedPlayerLabel.Text = "Selected Player: " .. (TeleportConfig.SelectedPlayerName or "None")
+        selectedPlayerLabel.Text = getText("SelectedPlayer") .. ": " .. (TeleportConfig.SelectedPlayerName or "None")
         selectedPlayerLabel.Font = Enum.Font.GothamBold
         selectedPlayerLabel.TextSize = 14
         selectedPlayerLabel.TextColor3 = Color3.new(1,1,1)
@@ -4317,7 +4362,7 @@ function showContent(tabName)
         teleportBtn = Instance.new("TextButton", functionsContainer)
         teleportBtn.Size = UDim2.new(1, -10, 0, 28)
         teleportBtn.Position = UDim2.new(0, 5, 0, currentY)
-        teleportBtn.Text = "START TELEPORT"
+        teleportBtn.Text = getText("StartTeleport")
         teleportBtn.Font = Enum.Font.GothamBold
         teleportBtn.TextSize = 14
         teleportBtn.TextColor3 = Color3.new(1,1,1)
@@ -4330,19 +4375,19 @@ function showContent(tabName)
             if not TeleportConfig.TargetPlayer then
                 teleportBtn.Text = "Select player first!"
                 task.wait(2)
-                teleportBtn.Text = "START TELEPORT"
+                teleportBtn.Text = getText("StartTeleport")
                 return
             end
             
             if TeleportConfig.Enabled then
                 stopTeleport()
                 TeleportConfig.Enabled = false
-                teleportBtn.Text = "START TELEPORT"
+                teleportBtn.Text = getText("StartTeleport")
                 teleportBtn.BackgroundColor3 = Color3.fromRGB(0,150,0)
             else
                 startTeleport()
                 TeleportConfig.Enabled = true
-                teleportBtn.Text = "STOP TELEPORT"
+                teleportBtn.Text = getText("StopTeleport")
                 teleportBtn.BackgroundColor3 = Color3.fromRGB(150,0,0)
             end
         end)
@@ -4351,7 +4396,7 @@ function showContent(tabName)
         local playerListLabel = Instance.new("TextLabel", functionsContainer)
         playerListLabel.Size = UDim2.new(1, -10, 0, 20)
         playerListLabel.Position = UDim2.new(0, 5, 0, currentY)
-        playerListLabel.Text = "Select Player for Teleport:"
+        playerListLabel.Text = getText("SelectPlayerForTeleport") .. ":"
         playerListLabel.Font = Enum.Font.GothamBold
         playerListLabel.TextSize = 12
         playerListLabel.TextColor3 = Color3.new(1,1,1)
@@ -4379,13 +4424,13 @@ function showContent(tabName)
                     playerBtn.MouseButton1Click:Connect(function()
                         TeleportConfig.TargetPlayer = player
                         TeleportConfig.SelectedPlayerName = player.Name
-                        selectedPlayerLabel.Text = "Selected Player: " .. player.Name
+                        selectedPlayerLabel.Text = getText("SelectedPlayer") .. ": " .. player.Name
                         
                         -- Обновляем цвет выбранного игрока
                         for _, child in pairs(functionsContainer:GetChildren()) do
                             if child:IsA("TextButton") and child.Text == player.Name then
                                 child.BackgroundColor3 = Color3.fromRGB(0,255,0)
-                            elseif child:IsA("TextButton") and child.Text ~= "START TELEPORT" and child.Text ~= "STOP TELEPORT" and child.Text ~= player.Name then
+                            elseif child:IsA("TextButton") and child.Text ~= getText("StartTeleport") and child.Text ~= getText("StopTeleport") and child.Text ~= player.Name then
                                 child.BackgroundColor3 = Color3.fromRGB(40,40,40)
                             end
                         end
@@ -4403,7 +4448,7 @@ function showContent(tabName)
         local standRangeLabel = Instance.new("TextLabel", functionsContainer)
         standRangeLabel.Size = UDim2.new(1, -10, 0, 20)
         standRangeLabel.Position = UDim2.new(0, 5, 0, currentY)
-        standRangeLabel.Text = "stand range hack"
+        standRangeLabel.Text = getText("StandRange")
         standRangeLabel.Font = Enum.Font.Gotham
         standRangeLabel.TextSize = 12
         standRangeLabel.TextColor3 = Color3.fromRGB(200, 200, 200)
@@ -4433,16 +4478,58 @@ function showContent(tabName)
             end
         end)
         
-        -- Ползунок скорости для YBA
+        -- Ползунок скорости для YBA (исправленный)
         createSlider("YBA Speed", 0.1, 10, YBAConfig.StandControlSpeed or 1.0, function(v)
             YBAConfig.StandControlSpeed = v
+            -- Применяем скорость к стенду если он активен
+            if isYBAEnabled and controlledStand and controlledStand.Root then
+                local bv = controlledStand.Root:FindFirstChild("BodyVelocity")
+                if bv then
+                    local currentVelocity = bv.Velocity
+                    if currentVelocity.Magnitude > 0 then
+                        bv.Velocity = currentVelocity.Unit * (v * 50)
+                    end
+                end
+            end
+            -- Также обновляем скорость для Underground Control
+            if isUndergroundControlEnabled then
+                YBAConfig.UndergroundControl.FlightSpeed = v * 50
+            end
         end)
+        
+        -- Добавляем переключатель NoClip в YBA Hacks
+        createDivider()
+        createSectionHeader("🟪 NoClip Settings")
+        local noClipStatusLabel = Instance.new("TextLabel", functionsContainer)
+        noClipStatusLabel.Size = UDim2.new(1, -10, 0, 20)
+        noClipStatusLabel.Position = UDim2.new(0, 5, 0, currentY)
+        noClipStatusLabel.Text = "NoClip Status: OFF"
+        noClipStatusLabel.Font = Enum.Font.GothamBold
+        noClipStatusLabel.TextSize = 12
+        noClipStatusLabel.TextColor3 = Color3.fromRGB(255,100,100)
+        noClipStatusLabel.BackgroundTransparency = 1
+        noClipStatusLabel.TextXAlignment = Enum.TextXAlignment.Left
+        currentY = currentY + 20 + padding
+        
+        local forceNoClipToggle = createToggleSlider("Force NoClip", isNoClipping, function(v)
+            if v then
+                startNoClip()
+                noClipStatusLabel.Text = "NoClip Status: ON"
+                noClipStatusLabel.TextColor3 = Color3.fromRGB(100,255,100)
+            else
+                stopNoClip()
+                noClipStatusLabel.Text = "NoClip Status: OFF"
+                noClipStatusLabel.TextColor3 = Color3.fromRGB(255,100,100)
+            end
+        end)
+        
+        createDivider()
         
         -- Anti Time Stop (кнопка с таймером)
         local antiTimeStopLabel = Instance.new("TextLabel", functionsContainer)
         antiTimeStopLabel.Size = UDim2.new(1, -10, 0, 20)
         antiTimeStopLabel.Position = UDim2.new(0, 5, 0, currentY)
-        antiTimeStopLabel.Text = "anti time stop"
+        antiTimeStopLabel.Text = getText("AntiTimeStopShort")
         antiTimeStopLabel.Font = Enum.Font.Gotham
         antiTimeStopLabel.TextSize = 12
         antiTimeStopLabel.TextColor3 = Color3.fromRGB(200, 200, 200)
@@ -4484,7 +4571,7 @@ function showContent(tabName)
         local itemESPLabel = Instance.new("TextLabel", functionsContainer)
         itemESPLabel.Size = UDim2.new(1, -10, 0, 20)
         itemESPLabel.Position = UDim2.new(0, 5, 0, currentY)
-        itemESPLabel.Text = "item esp"
+        itemESPLabel.Text = getText("Item")
         itemESPLabel.Font = Enum.Font.Gotham
         itemESPLabel.TextSize = 12
         itemESPLabel.TextColor3 = Color3.fromRGB(200, 200, 200)


### PR DESCRIPTION
Improves UI responsiveness and localization, fixes YBA speed control, and adds a NoClip toggle.

This PR addresses several user-reported issues in `sosiski3.lua`:
-   **Accent Color:** Ensures the accent color updates immediately on sliders and applies correctly to tab highlights.
-   **Translations:** Adds missing translations for various game features (e.g., 'Selected Player', 'Stand Range', 'Anti Time Stop') and item names.
-   **Speed Control:** Corrects the YBA speed slider to properly affect stand and underground movement speed.
-   **NoClip Toggle:** Integrates a dedicated NoClip toggle into the YBA hacks section, mirroring the main tab's functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-87e7f70c-4860-4274-a646-449b1a2222ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87e7f70c-4860-4274-a646-449b1a2222ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

